### PR TITLE
feat: support full text scan strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ function App() {
 | scanGlob            | `string[]`           | [look this way](./src/core/utils.ts/#L41)                        |  the glob pattern used in tree-shaking                                          |
 | scanStrategy            | `text \| component`       | component                        |  the scan strategy used in tree-shaking                                          |
 
+> Tip: if you use `scanStrategy: 'text'`, you should keep the icon name unique as much as possible to avoid increase the build size.
 
 ## Typescript support
 ```json

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ function App() {
 | svgSpriteDomId        | `string`                   | __svg_sprite__dom__                            | Customize the ID of the svgDom                      |
 | vueVersion            | `2 \| 3 \| auto`           | auto                                           | Vue version                                         |
 | scanGlob            | `string[]`           | [look this way](./src/core/utils.ts/#L41)                        |  the glob pattern used in tree-shaking                                          |
+| scanStrategy            | `text \| component`       | component                        |  the scan strategy used in tree-shaking                                          |
 
 
 ## Typescript support

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -157,6 +157,7 @@ function App() {
 | svgSpriteDomId        | `string`                   | __svg_sprite__dom__                            | 自定义生成的svg元素的id                                  |
 | vueVersion            | `2 \| 3 \| auto`           | auto                                           | Vue 版本, 默认会自动检测                                  |
 | scanGlob            | `string[]`           | [code](./src/core/utils.ts/#L41)                       | 用于 tree-shaking 的模式匹配路径 |
+| scanStrategy            | `text \| component`           | component                       | 用于 tree-shaking 的模式匹配策略 |
 
 
 ## Typescript 支持

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -159,6 +159,7 @@ function App() {
 | scanGlob            | `string[]`           | [code](./src/core/utils.ts/#L41)                       | 用于 tree-shaking 的模式匹配路径 |
 | scanStrategy            | `text \| component`           | component                       | 用于 tree-shaking 的模式匹配策略 |
 
+> 提示: 如果你使用 `scanStrategy: 'text'`, 你应该尽可能的保证图标名称的独特性，以此避免增加构建后的文件大小。
 
 ## Typescript 支持
 ```json

--- a/examples/vue3-vite/vite.config.ts
+++ b/examples/vue3-vite/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       },
       optimizeOptions: undefined,
       vueVersion: 3,
+      scanStrategy: 'text'
     }),
   ],
 })

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -4,7 +4,14 @@ import fg from 'fast-glob'
 import type { Options } from '../types'
 
 export default async function scanUsedSvgNames(options: Options) {
-  const { componentName, scanGlob } = options
+  const { componentName, scanGlob, iconDir, scanStrategy,symbolIdFormatter, prefix } = options
+
+  const allSvgNames = fg.sync(['**/*.svg'], { cwd: iconDir })
+                      .map(n => symbolIdFormatter!(n, prefix!))
+                      .sort((a,b) => b.length - a.length)
+
+  const testReg = new RegExp(`(${allSvgNames.join('|')})`, 'gm')
+
   const svgCompnentRE = new RegExp(
     `\\<\\s*${componentName}[^\\<]+name=[\\"\\'](\\S+)[\\"\\'][^\\<]*\\/\\>`, 'g',
   )
@@ -18,9 +25,15 @@ export default async function scanUsedSvgNames(options: Options) {
       'vite.config.js',
     ],
   })
+
   const scanExecutors = filenames.map(async (f) => {
     const code = await fs.readFile(path.resolve(process.cwd(), f), 'utf-8')
-    return Array.from(code.matchAll(svgCompnentRE)).map(match => match[1])
+
+    if (scanStrategy === 'component') {
+      return Array.from(code.matchAll(svgCompnentRE)).map(match => match[1])
+    } else {
+      return [...(code.match(testReg) || [])]
+    }
   })
 
   const svgNames = await Promise.all(scanExecutors)

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -47,6 +47,7 @@ export function resolveOptions(options: Options): Options {
       '**/*.tsx',
       '**/*.jsx',
     ],
+    scanStrategy: 'component'
   }
   return {
     ...defaultOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface Options {
   projectType?: 'vue' | 'react' | 'auto'
   vueVersion?: VueVersion
   scanGlob?: string[]
+  scanStrategy?: 'text' | 'component'
 }
 
 export type VueVersion = 2 | 3 | 'auto'


### PR DESCRIPTION
At some scenarios, we need to use config file to set icon instead of using `SvgIcon` directly.

Another scenario is that we may need to wrap a component of `SvgIcon` to set some extra style and props.

So I made an option `scanStrategy` to support these scenarios.

BTW, Thank you for made this awesome plugin.