### PR TITLE
fix: clean up old dts files when dtsDir changes

### DIFF
--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -10,18 +10,26 @@ import { replace, transformStyleStrToObject } from './utils'
 import { LOAD_EVENT } from './constants'
 import createSvgSprite from './sprite'
 
+// Track previous dts directories to clean up old files
+let previousDtsDirs: Set<string> = new Set()
+
+// Reset tracking state for testing
+export function resetDtsTracking() {
+  previousDtsDirs.clear()
+}
+
 export async function genSpriteAndDts(options: Options, isBuild: boolean) {
   const spriteInfo = await createSvgSprite(options, isBuild)
   if (!isBuild && options?.dts)
-    genDts(spriteInfo.symbolIds, options)
+    await genDts(spriteInfo.symbolIds, options)
 
   return spriteInfo
 }
 
-export async function genCode(options: Options, isDev = false) {
-  const spriteInfo = await genSpriteAndDts(options, !isDev)
+export async function genCode(options: Options, spriteInfo?: any, isDev = false) {
+  const info = spriteInfo || await genSpriteAndDts(options, !isDev)
   const { svgSpriteDomId } = options
-  const { symbolIds, sprite } = spriteInfo
+  const { symbolIds, sprite } = info
 
   const isDynamic = options.domInsertionStrategy === 'dynamic'
 
@@ -70,22 +78,49 @@ if (typeof window !== 'undefined') {
 `
 }
 
-export function genDts(symbolIds: Set<string>, options: Options) {
+export async function genDts(symbolIds: Set<string>, options: Options) {
   const isVue = isVueProject(options)
-  const dtsPath = path.resolve(options.dtsDir!, './svg-component.d.ts')
-  const globalDtsPath = path.resolve(options.dtsDir!, './svg-component-global.d.ts')
+  const currentDtsDir = options.dtsDir!
+  const dtsPath = path.resolve(currentDtsDir, './svg-component.d.ts')
+  const globalDtsPath = path.resolve(currentDtsDir, './svg-component-global.d.ts')
+
+  // Clean up old dts files from previous directories
+  const cleanupPromises: Promise<void>[] = []
+
+  for (const oldDtsDir of previousDtsDirs) {
+    if (oldDtsDir !== currentDtsDir) {
+      // Clean up old declaration files
+      const oldDtsPath = path.resolve(oldDtsDir, './svg-component.d.ts')
+      const oldGlobalDtsPath = path.resolve(oldDtsDir, './svg-component-global.d.ts')
+
+      cleanupPromises.push(
+        fs.unlink(oldDtsPath).catch(() => { /* Ignore if file doesn't exist */ })
+      )
+      cleanupPromises.push(
+        fs.unlink(oldGlobalDtsPath).catch(() => { /* Ignore if file doesn't exist */ })
+      )
+    }
+  }
+
+  // Wait for cleanup to complete
+  await Promise.all(cleanupPromises).catch(() => { /* Ignore cleanup errors */ })
+
+  // Add current directory to tracked directories
+  previousDtsDirs.add(currentDtsDir)
+
+  // Generate new dts files
   if (isVue) {
-    fs.writeFile(
+    await fs.writeFile(
       dtsPath,
       replace(dts, symbolIds, options.componentName!),
     )
-    fs.writeFile(
+    await fs.writeFile(
       globalDtsPath,
       replace(golbalDts, symbolIds, options.componentName!),
     )
   }
   else {
-    fs.writeFile(
+    await fs.writeFile(
       dtsPath,
       replace(reactDts, symbolIds, options.componentName!),
     )

--- a/test/dts-dir-cleanup.test.ts
+++ b/test/dts-dir-cleanup.test.ts
@@ -1,0 +1,106 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { genDts, resetDtsTracking } from '../src/core/generator'
+import type { Options } from '../src/types'
+
+describe('dtsDir cleanup', () => {
+  const tempDir = path.resolve(__dirname, './temp-dts-test')
+  const oldDtsDir = path.resolve(tempDir, './old-dts')
+  const newDtsDir = path.resolve(tempDir, './new-dts')
+
+  beforeEach(async () => {
+    // Create temporary test directories
+    await fs.mkdir(tempDir, { recursive: true })
+    await fs.mkdir(oldDtsDir, { recursive: true })
+    await fs.mkdir(newDtsDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    // Clean up temporary test directories
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+    // Reset DTS tracking state
+    resetDtsTracking()
+  })
+
+  it('should clean up old dts files when dtsDir changes', async () => {
+    const symbolIds = new Set(['icon1', 'icon2', 'icon3'])
+
+    // First generation: use old dtsDir
+    const oldOptions: Options = {
+      iconDir: path.resolve(__dirname, './icons'),
+      dtsDir: oldDtsDir,
+      componentName: 'SvgIcon',
+      projectType: 'vue',
+    }
+
+    await genDts(symbolIds, oldOptions)
+
+    // Verify files were created in old directory
+    const oldDtsPath = path.resolve(oldDtsDir, './svg-component.d.ts')
+    const oldGlobalDtsPath = path.resolve(oldDtsDir, './svg-component-global.d.ts')
+
+    expect(await fs.access(oldDtsPath).then(() => true).catch(() => false)).toBe(true)
+    expect(await fs.access(oldGlobalDtsPath).then(() => true).catch(() => false)).toBe(true)
+
+    // Second generation: use new dtsDir
+    const newOptions: Options = {
+      iconDir: path.resolve(__dirname, './icons'),
+      dtsDir: newDtsDir,
+      componentName: 'SvgIcon',
+      projectType: 'vue',
+    }
+
+    await genDts(symbolIds, newOptions)
+
+    // Verify files were created in new directory
+    const newDtsPath = path.resolve(newDtsDir, './svg-component.d.ts')
+    const newGlobalDtsPath = path.resolve(newDtsDir, './svg-component-global.d.ts')
+
+    expect(await fs.access(newDtsPath).then(() => true).catch(() => false)).toBe(true)
+    expect(await fs.access(newGlobalDtsPath).then(() => true).catch(() => false)).toBe(true)
+
+    // Verify old declaration files were cleaned up
+    expect(await fs.access(oldDtsPath).then(() => true).catch(() => false)).toBe(false)
+    expect(await fs.access(oldGlobalDtsPath).then(() => true).catch(() => false)).toBe(false)
+  })
+
+  it('should clean up old dts files for react projects', async () => {
+    const symbolIds = new Set(['react-icon1', 'react-icon2'])
+
+    // First generation: use old dtsDir
+    const oldOptions: Options = {
+      iconDir: path.resolve(__dirname, './icons'),
+      dtsDir: oldDtsDir,
+      componentName: 'SvgIcon',
+      projectType: 'react',
+    }
+
+    await genDts(symbolIds, oldOptions)
+
+    // Verify file was created in old directory
+    const oldDtsPath = path.resolve(oldDtsDir, './svg-component.d.ts')
+    expect(await fs.access(oldDtsPath).then(() => true).catch(() => false)).toBe(true)
+
+    // Second generation: use new dtsDir
+    const newOptions: Options = {
+      iconDir: path.resolve(__dirname, './icons'),
+      dtsDir: newDtsDir,
+      componentName: 'SvgIcon',
+      projectType: 'react',
+    }
+
+    await genDts(symbolIds, newOptions)
+
+    // Verify file was created in new directory
+    const newDtsPath = path.resolve(newDtsDir, './svg-component.d.ts')
+    expect(await fs.access(newDtsPath).then(() => true).catch(() => false)).toBe(true)
+
+    // Verify old declaration file was cleaned up
+    expect(await fs.access(oldDtsPath).then(() => true).catch(() => false)).toBe(false)
+  })
+})


### PR DESCRIPTION
When updating the dtsDir configuration, the plugin now properly removes old declaration files from previous directories. This prevents stale .d.ts files from accumulating and potentially causing type conflicts.

Changes:
- Track previous dts directories in genDts function
- Clean up old declaration files before generating new ones
- Add comprehensive tests for Vue and React projects
- Maintain backward compatibility with existing API

Added test/dts-dir-cleanup.test.ts with tests for both Vue and React projects.