### PR TITLE
fix: add root package entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
@@ -62,7 +62,7 @@
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",
-  "types": "dist/types.d.ts",
+  "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
       "*": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+import unplugin from './core'
+
+export default unplugin
+export * from './types'


### PR DESCRIPTION
# fix: add root package entrypoint

## Summary

- Add a root `src/index.ts` entry so the build emits `dist/index.js`, `dist/index.cjs`, and root declarations.
- Point package root types at `dist/index.d.ts`.

## Why

The package currently advertises root ESM and CJS entrypoints:

- `dist/index.js`
- `dist/index.cjs`

But the published tarball does not include those files, so both `import('unplugin-svg-component')` and `require('unplugin-svg-component')` fail with module-not-found errors. Bundler-specific subpaths like `unplugin-svg-component/vite` resolve correctly.

## Verification

- `corepack pnpm run build`
- `npm pack --dry-run --ignore-scripts --json`
- `corepack pnpm test -- --run`
- `corepack pnpm exec eslint ./src`
- Confirmed the packed files include `dist/index.js`, `dist/index.cjs`, and `dist/index.d.ts`
- Confirmed a local consumer can both import and require the fixed package root

Attempted but not completed locally:

- `corepack pnpm -C e2e-test test` timed out after about 184 seconds with no useful output. I stopped the residual Node/Playwright processes afterward.
- `corepack pnpm -C e2e-test exec playwright test tests/basic.spec.ts --workers=1 --timeout=60000` also timed out with no useful output. I stopped the residual Playwright/corepack processes afterward.

Not yet run locally:

- Exact `pnpm lint` script
- Passing `pnpm test:e2e`

Note: this repo's `pnpm lint` script runs ESLint with `--fix`, so it should be treated as a potentially modifying command.
